### PR TITLE
feat: added drink messages

### DIFF
--- a/src/main/java/net/kath/medieval_rpg_for_dummies/MedievalRpgMod.java
+++ b/src/main/java/net/kath/medieval_rpg_for_dummies/MedievalRpgMod.java
@@ -3,6 +3,7 @@ package net.kath.medieval_rpg_for_dummies;
 import com.mojang.logging.LogUtils;
 import net.kath.medieval_rpg_for_dummies.block.ModBlocks;
 import net.kath.medieval_rpg_for_dummies.item.ModItems;
+import net.kath.medieval_rpg_for_dummies.networking.ModMessages;
 import net.kath.medieval_rpg_for_dummies.painting.ModPaintings;
 import net.kath.medieval_rpg_for_dummies.villager.ModVillagers;
 import net.kath.medieval_rpg_for_dummies.world.feature.ModConfiguredFeatures;
@@ -45,6 +46,8 @@ public class MedievalRpgMod {
 
     private void commonSetup(final FMLCommonSetupEvent event) {
         event.enqueueWork(ModVillagers::registerPOIs);
+
+        ModMessages.register();
     }
 
     @Mod.EventBusSubscriber(modid = MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)

--- a/src/main/java/net/kath/medieval_rpg_for_dummies/event/ClientEvents.java
+++ b/src/main/java/net/kath/medieval_rpg_for_dummies/event/ClientEvents.java
@@ -1,6 +1,9 @@
 package net.kath.medieval_rpg_for_dummies.event;
 
 import net.kath.medieval_rpg_for_dummies.MedievalRpgMod;
+import net.kath.medieval_rpg_for_dummies.networking.ModMessages;
+import net.kath.medieval_rpg_for_dummies.networking.packet.C2SPacket;
+import net.kath.medieval_rpg_for_dummies.networking.packet.DrinkWaterC2SPacket;
 import net.kath.medieval_rpg_for_dummies.util.KeyBinding;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
@@ -20,7 +23,7 @@ public class ClientEvents {
       if (KeyBinding.DRINKING_KEY.consumeClick()) {
         if (Minecraft.getInstance().player == null) return;
 
-        Minecraft.getInstance().player.sendSystemMessage(Component.literal("You pressed the key!"));
+        ModMessages.sendToServer(new DrinkWaterC2SPacket());
       }
     }
 

--- a/src/main/java/net/kath/medieval_rpg_for_dummies/networking/ModMessages.java
+++ b/src/main/java/net/kath/medieval_rpg_for_dummies/networking/ModMessages.java
@@ -1,0 +1,53 @@
+package net.kath.medieval_rpg_for_dummies.networking;
+
+import net.kath.medieval_rpg_for_dummies.MedievalRpgMod;
+import net.kath.medieval_rpg_for_dummies.networking.packet.C2SPacket;
+import net.kath.medieval_rpg_for_dummies.networking.packet.DrinkWaterC2SPacket;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkDirection;
+import net.minecraftforge.network.NetworkRegistry;
+import net.minecraftforge.network.PacketDistributor;
+import net.minecraftforge.network.simple.SimpleChannel;
+
+public class ModMessages {
+
+  private static SimpleChannel INSTANCE;
+
+  private static int packetId = 0;
+  private static int id() {
+    return packetId++;
+  }
+
+  public static void register() {
+    SimpleChannel net = NetworkRegistry.ChannelBuilder
+            .named(new ResourceLocation(MedievalRpgMod.MOD_ID, "messages"))
+            .networkProtocolVersion(() -> "1.0")
+            .clientAcceptedVersions(s -> true)
+            .serverAcceptedVersions(s -> true)
+            .simpleChannel();
+
+    INSTANCE = net;
+
+    net.messageBuilder(C2SPacket.class, id(), NetworkDirection.PLAY_TO_SERVER)
+            .encoder(C2SPacket::toBytes)
+            .decoder(C2SPacket::new)
+            .consumerMainThread(C2SPacket::handle)
+            .add();
+
+    net.messageBuilder(DrinkWaterC2SPacket.class, id(), NetworkDirection.PLAY_TO_SERVER)
+            .encoder(DrinkWaterC2SPacket::toBytes)
+            .decoder(DrinkWaterC2SPacket::new)
+            .consumerMainThread(DrinkWaterC2SPacket::handle)
+            .add();
+  }
+
+  public static <MSG> void sendToServer(MSG message) {
+    INSTANCE.sendToServer(message);
+  }
+
+  public static <MSG> void sendToPlayer(MSG message, ServerPlayer player) {
+    INSTANCE.send(PacketDistributor.PLAYER.with(() -> player), message);
+  }
+
+}

--- a/src/main/java/net/kath/medieval_rpg_for_dummies/networking/packet/C2SPacket.java
+++ b/src/main/java/net/kath/medieval_rpg_for_dummies/networking/packet/C2SPacket.java
@@ -1,0 +1,35 @@
+package net.kath.medieval_rpg_for_dummies.networking.packet;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class C2SPacket {
+
+  public C2SPacket() {
+  }
+
+  public C2SPacket(FriendlyByteBuf buf) {
+  }
+
+  public void toBytes(FriendlyByteBuf buf) {
+  }
+
+  public boolean handle(Supplier<NetworkEvent.Context> supplier) {
+    NetworkEvent.Context context = supplier.get();
+    context.enqueueWork(() -> {
+      ServerPlayer player = context.getSender();
+      ServerLevel level = player.getLevel();
+
+      EntityType.COW.spawn(level, null, null, player.blockPosition(), MobSpawnType.COMMAND, true, false);
+    });
+
+    return true;
+  }
+
+}

--- a/src/main/java/net/kath/medieval_rpg_for_dummies/networking/packet/DrinkWaterC2SPacket.java
+++ b/src/main/java/net/kath/medieval_rpg_for_dummies/networking/packet/DrinkWaterC2SPacket.java
@@ -1,0 +1,56 @@
+package net.kath.medieval_rpg_for_dummies.networking.packet;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class DrinkWaterC2SPacket {
+
+  private static final String MESSAGE_DRINK_WATER = "message.medieval_rpg_for_dummies.drink_water";
+  private static final String MESSAGE_NO_WATER = "message.medieval_rpg_for_dummies.no_water";
+
+  public DrinkWaterC2SPacket() {
+  }
+
+  public DrinkWaterC2SPacket(FriendlyByteBuf buf) {
+  }
+
+  public void toBytes(FriendlyByteBuf buf) {
+  }
+
+  public boolean handle(Supplier<NetworkEvent.Context> supplier) {
+    NetworkEvent.Context context = supplier.get();
+    context.enqueueWork(() -> {
+      ServerPlayer player = context.getSender();
+      ServerLevel level = player.getLevel();
+
+      if (hasWaterAroundThem(player, level, 2)) {
+        player.sendSystemMessage(Component.translatable(MESSAGE_DRINK_WATER).withStyle(ChatFormatting.DARK_AQUA));
+
+        level.playSound(null, player.getOnPos(), SoundEvents.GENERIC_DRINK, SoundSource.PLAYERS,
+                0.5F, level.random.nextFloat() * 0.1F + 0.9F);
+      } else {
+        player.sendSystemMessage(Component.translatable(MESSAGE_NO_WATER).withStyle(ChatFormatting.RED));
+      }
+    });
+
+    return true;
+  }
+
+  private boolean hasWaterAroundThem(ServerPlayer player, ServerLevel level, int size) {
+    return level.getBlockStates(player.getBoundingBox().inflate(size))
+            .filter(state -> state.is(Blocks.WATER)).toArray().length > 0;
+  }
+
+}

--- a/src/main/resources/assets/medieval_rpg_for_dummies/lang/en_us.json
+++ b/src/main/resources/assets/medieval_rpg_for_dummies/lang/en_us.json
@@ -19,5 +19,8 @@
   "key.category.medieval_rpg_for_dummies.tutorial": "Medieval RPG for Dummies Category",
   "key.medieval_rpg_for_dummies.drink_water": "Drink Water",
 
+  "message.medieval_rpg_for_dummies.drink_water": "You drank water!",
+  "message.medieval_rpg_for_dummies.no_water": "There is no water nearby!",
+
   "itemGroup.medieval_rpg_for_dummies": "Medieval RPG for Dummies"
 }


### PR DESCRIPTION
Added drink feature to the key binding that verify if there is water around the player and them send a message saying that the player is drinking water, but if there isn't any water source nearby we send a message that says there is not water nearby.